### PR TITLE
Fix multiple search boxes showing

### DIFF
--- a/doc/template/js/ns.js
+++ b/doc/template/js/ns.js
@@ -74,7 +74,7 @@ function ns_search_box(display) {
     sb_html += '</li>';
 
     // TODO: Should we do something else if .tablist is not found?
-    nav.find('.tablist').append(sb_html);
+    nav.find('.tablist:first').append(sb_html);
     $(nav_container).append(nav);
 
     //


### PR DESCRIPTION
When one modifies the layout.xml file to show tabs like "Indexes", it shows one search
box per navrow. This commit fixes this problem.